### PR TITLE
stricter check for undef to avoid asset id bug

### DIFF
--- a/src/js/app/view/list_picker.js
+++ b/src/js/app/view/list_picker.js
@@ -24,7 +24,7 @@ export default Modal.extend({
     },
 
     init: function ({list, submit, useFilter}) {
-        this.list = list.map(([c, k], i) => [c, k || c, i]);
+        this.list = list.map(([c, k], i) => [c, k !== undefined ? k : i]);
         this._list = this.list;
         this.submit = submit;
         this.useFilter = !!useFilter;


### PR DESCRIPTION
Clicking the top of the asset index list was causing the unknown id issue due to a loose check for `undefined`