### PR TITLE
only load 50 list elements at a time for perf.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ gulp.task('js', function() {
     .pipe(notify('Landmarker.io: JS rebuilt'));
 });
 
-// Rebuild the SCSS and pass throuhg autoprefixer output
+// Rebuild the SCSS and pass through autoprefixer output
 // + issue a notification when done.
 gulp.task('sass', function () {
     return gulp.src(entry.scss)


### PR DESCRIPTION
Now only the first 50 elements by default are placed in the DOM in the asset list. A 'Load more..' button is automatically appended to the list to increase the list size if there are more than 50 elements in the list.

This change keeps performance acceptable on large datasets.