### PR TITLE
WIP: fastclick for iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "backbone": "^1.1.2",
     "browserify": "^8.1.1",
     "del": "^1.1.1",
+    "fastclick": "^1.0.6",
     "gulp": "^3.8.10",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-buffer": "0.0.2",

--- a/src/js/app/view/sidebar.js
+++ b/src/js/app/view/sidebar.js
@@ -16,7 +16,7 @@ export const LandmarkView = Backbone.View.extend({
     tagName: "div",
 
     events: {
-        click: "handleClick"
+        click: "select"
     },
 
     initialize: function ({labelIndex}) {

--- a/src/js/app/view/toolbar.js
+++ b/src/js/app/view/toolbar.js
@@ -82,7 +82,7 @@ export const ConnectivityToggle = Backbone.View.extend({
     el: '#connectivityRow',
 
     events: {
-        'click #connectivityToggle': "connectivityToggle"
+        click: "connectivityToggle"
     },
 
     initialize: function () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,6 +17,7 @@ import ToolbarView from './app/view/toolbar';
 import URLState from './app/view/url_state';
 import ViewportView from './app/view/viewport';
 import KeyboardShortcutsHandler from './app/view/keyboard';
+import attachFastClick from 'fastclick';
 
 import Config from './app/model/config';
 import App from './app/model/app';
@@ -300,6 +301,11 @@ document.addEventListener('DOMContentLoaded', function () {
             type: 'error'
         });
     }
+
+    // Have nice fast clicks on iOS (should be removed once this makes it into
+    // iOS)
+    // https://trac.webkit.org/changeset/191072
+    attachFastClick(document.body);
 
     cfg.load();
     Intro.init({cfg});


### PR DESCRIPTION
This PR is a work in progress (WIP).

I'm thinking of reneging on #96 and adding fast click support for iOS in the interim until the next release of Safari. My major motivation is that I'm looking at the iPad Pro and thinking it would be interesting to explore annotation with the Apple Pencil...

In general, just including fastclick does really improve the experience on using the majority of the interface, however, there are issues.

#### Known Issues:
- [ ] toggles in bottom left sidebar behaving strangely
- [ ] clicks in Viewport does not seem to be registering
- [ ] clicks in landmark table still feel weirdly slow (there is a delay before the selected colour shows. This may be unrelated to fast click though?)

#### Usability tests
Just to check we aren't causing weird issues on other platforms:
- [ ] Chrome
- [ ] Chrome Android
- [ ] Firefox
- [ ] Safari OS X
- [ ] Microsoft Edge

If it turns out we can fix all these issues with minimal changes, then I think we can bring this in as a crutch for the next year.