### PR TITLE
fix publicPath so it works for dev/prod builds

### DIFF
--- a/webpack/webpack.base.config.js
+++ b/webpack/webpack.base.config.js
@@ -4,7 +4,6 @@ module.exports = {
     entry: "./src/js/index.js",
     output: {
         path: path.join(path.dirname(__dirname), 'build'),
-        publicPath: "./",
         filename: "bundle.js"
     },
     module: {

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -7,6 +7,11 @@ var REMOTE_CACHED = [
     '//cdnjs.cloudflare.com/ajax/libs/octicons/2.4.1/octicons.css'
 ];
 
+// in production we use relative paths so staging builds work properly.
+// (we can't do this for dev as relative paths seem to not play well
+// with webpack-dev-server)
+webpackConfig.output.publicPath = './';
+
 webpackConfig.devtool = "source-map";  // full separate source maps
 webpackConfig.bail = true;  // at any error just fallover
 webpackConfig.plugins = webpackConfig.plugins.concat(


### PR DESCRIPTION
It seems webpack-dev-server doesn't work well with relative paths. We want to use a relative path on deploy so staging/ builds work. This changes our webpack config to use relative paths in our builds, but absolute for dev builds.