### PR TITLE
(WIP) Advanced selection box

### DIFF
--- a/src/ts/app/view/bbviewport.ts
+++ b/src/ts/app/view/bbviewport.ts
@@ -81,7 +81,7 @@ export class BackboneViewport {
     }
 
     updateConnectivityDisplay = () => {
-        this.viewport.connectivityVisable = this.model.isConnectivityOn
+        this.viewport.connectivityVisible = this.model.isConnectivityOn
     }
 
     updateLandmark = (i: number) => {

--- a/src/ts/app/view/viewport/canvas.ts
+++ b/src/ts/app/view/viewport/canvas.ts
@@ -181,6 +181,7 @@ export class Canvas implements ICanvas {
     drawCircle = (centre: THREE.Vector2, radius: number) => {
         this.ctx.beginPath()
         this.ctx.arc(centre.x, centre.y, radius, 0, 2 * Math.PI, false)
+        this.ctx.fillStyle = "#01e6fb"
         this.ctx.fill()
         this.ctx.stroke()
         // update the bounding box

--- a/src/ts/app/view/viewport/canvas.ts
+++ b/src/ts/app/view/viewport/canvas.ts
@@ -18,16 +18,16 @@ interface Bounds {
     height: number
 }
 
-function initialBoundingBox() {
+function initialBoundingBox() : BoundingBox {
     return { minX: 999999, minY: 999999, maxX: 0, maxY: 0 }
 }
 
 export interface ICanvas {
-    pipVisable: boolean
+    pipVisible: boolean
     resize: (width: number, height: number) => void
     clear: () => void,
     drawTargetingLines: (point: THREE.Vector2, targetPoint: THREE.Vector2, secondaryPoints: THREE.Vector2[]) => void
-    drawSelectionBox: (mouseDown: THREE.Vector2, mousePosition: THREE.Vector2) => void,
+    drawSelectionBox: (pointA: THREE.Vector2, pointB: THREE.Vector2) => void,
     pipBounds: (width: number, height: number) => Bounds
 }
 
@@ -42,7 +42,7 @@ export class Canvas implements ICanvas {
     // drawing into each frame. This way we only need clear the relevant
     // area of the canvas which is a big perf win.
     // see this._updateCanvasBoundingBox() for usage.
-    ctxBox = initialBoundingBox()
+    ctxBox: BoundingBox = initialBoundingBox()
     pixelRatio = window.devicePixelRatio || 1  // 2/3 if on a HIDPI/retina display
 
     constructor(canvas: HTMLCanvasElement, pipCanvas: HTMLCanvasElement) {
@@ -62,7 +62,7 @@ export class Canvas implements ICanvas {
         // as we don't know the screen size at this time.
 
         // by default hide the PIP window.
-        this.pipVisable = false
+        this.pipVisible = false
 
         // To compensate for retina displays we have to manually
         // scale our contexts up by the pixel ratio. To counteract this (so we
@@ -87,12 +87,12 @@ export class Canvas implements ICanvas {
         this.pipCtx.strokeRect(0, 0, PIP_WIDTH, PIP_HEIGHT)
     }
 
-    get pipVisable() {
+    get pipVisible() {
         return this.pipCanvas.style.display !== 'none'
     }
 
-    set pipVisable(isVisable) {
-        this.pipCanvas.style.display = isVisable ? null : 'none'
+    set pipVisible(isVisible) {
+        this.pipCanvas.style.display = isVisible ? null : 'none'
     }
 
     pipBounds = (width: number, height: number) => {
@@ -125,15 +125,15 @@ export class Canvas implements ICanvas {
         this.ctxBox.maxY = Math.max(this.ctxBox.maxY, point.y)
     }
 
-    drawSelectionBox = (mouseDown: THREE.Vector2, mousePosition: THREE.Vector2) => {
-        var x = mouseDown.x
-        var y = mouseDown.y
-        var dx = mousePosition.x - x
-        var dy = mousePosition.y - y
+    drawSelectionBox = (pointA: THREE.Vector2, pointB: THREE.Vector2) => {
+        var x = pointA.x
+        var y = pointA.y
+        var dx = pointB.x - x
+        var dy = pointB.y - y
         this.ctx.strokeRect(x, y, dx, dy)
         // update the bounding box
-        this.updateCanvasBoundingBox(mouseDown)
-        this.updateCanvasBoundingBox(mousePosition)
+        this.updateCanvasBoundingBox(pointA)
+        this.updateCanvasBoundingBox(pointB)
     }
 
     drawTargetingLines = (point: THREE.Vector2,

--- a/src/ts/app/view/viewport/canvas.ts
+++ b/src/ts/app/view/viewport/canvas.ts
@@ -27,9 +27,9 @@ export interface ICanvas {
     resize: (width: number, height: number) => void
     clear: () => void,
     drawTargetingLines: (point: THREE.Vector2, targetPoint: THREE.Vector2, secondaryPoints: THREE.Vector2[]) => void
-    drawSelectionBox: (pointA: THREE.Vector2, pointB: THREE.Vector2) => void,
-    drawLine: (pointA: THREE.Vector2, pointB: THREE.Vector2) => void,
-    drawCircle: (centre: THREE.Vector2, radius: number) => void,
+    drawBox: (pointA: THREE.Vector2, pointB: THREE.Vector2, colour: string, fillColour: string) => void,
+    drawLine: (pointA: THREE.Vector2, pointB: THREE.Vector2, colour: string) => void,
+    drawCircle: (centre: THREE.Vector2, radius: number, colour: string) => void,
     pipBounds: (width: number, height: number) => Bounds
 }
 
@@ -127,11 +127,14 @@ export class Canvas implements ICanvas {
         this.ctxBox.maxY = Math.max(this.ctxBox.maxY, point.y)
     }
 
-    drawSelectionBox = (pointA: THREE.Vector2, pointB: THREE.Vector2) => {
+    drawBox = (pointA: THREE.Vector2, pointB: THREE.Vector2, colour: string, fillColour: string) => {
+        this.ctx.strokeStyle = colour
+        this.ctx.fillStyle = fillColour
         var x = pointA.x
         var y = pointA.y
         var dx = pointB.x - x
         var dy = pointB.y - y
+        this.ctx.fillRect(x, y, dx, dy)
         this.ctx.strokeRect(x, y, dx, dy)
         // update the bounding box
         this.updateCanvasBoundingBox(pointA)
@@ -168,7 +171,8 @@ export class Canvas implements ICanvas {
         this.ctx.stroke()
     }
 
-    drawLine = (pointA: THREE.Vector2, pointB: THREE.Vector2) => {
+    drawLine = (pointA: THREE.Vector2, pointB: THREE.Vector2, colour: string) => {
+        this.ctx.strokeStyle = colour
         this.ctx.beginPath()
         this.ctx.moveTo(pointA.x, pointA.y)
         this.ctx.lineTo(pointB.x, pointB.y)
@@ -178,10 +182,11 @@ export class Canvas implements ICanvas {
         this.updateCanvasBoundingBox(pointB)
     }
 
-    drawCircle = (centre: THREE.Vector2, radius: number) => {
+    drawCircle = (centre: THREE.Vector2, radius: number, colour: string) => {
+        this.ctx.strokeStyle = colour
         this.ctx.beginPath()
         this.ctx.arc(centre.x, centre.y, radius, 0, 2 * Math.PI, false)
-        this.ctx.fillStyle = "#01e6fb"
+        this.ctx.fillStyle = colour
         this.ctx.fill()
         this.ctx.stroke()
         // update the bounding box

--- a/src/ts/app/view/viewport/canvas.ts
+++ b/src/ts/app/view/viewport/canvas.ts
@@ -28,6 +28,8 @@ export interface ICanvas {
     clear: () => void,
     drawTargetingLines: (point: THREE.Vector2, targetPoint: THREE.Vector2, secondaryPoints: THREE.Vector2[]) => void
     drawSelectionBox: (pointA: THREE.Vector2, pointB: THREE.Vector2) => void,
+    drawLine: (pointA: THREE.Vector2, pointB: THREE.Vector2) => void,
+    drawCircle: (centre: THREE.Vector2, radius: number) => void,
     pipBounds: (width: number, height: number) => Bounds
 }
 
@@ -164,6 +166,26 @@ export class Canvas implements ICanvas {
         this.ctx.moveTo(targetPoint.x, targetPoint.y)
         this.ctx.lineTo(point.x, point.y)
         this.ctx.stroke()
+    }
+
+    drawLine = (pointA: THREE.Vector2, pointB: THREE.Vector2) => {
+        this.ctx.beginPath()
+        this.ctx.moveTo(pointA.x, pointA.y)
+        this.ctx.lineTo(pointB.x, pointB.y)
+        this.ctx.stroke()
+        // update the bounding box
+        this.updateCanvasBoundingBox(pointA)
+        this.updateCanvasBoundingBox(pointB)
+    }
+
+    drawCircle = (centre: THREE.Vector2, radius: number) => {
+        this.ctx.beginPath()
+        this.ctx.arc(centre.x, centre.y, radius, 0, 2 * Math.PI, false)
+        this.ctx.fill()
+        this.ctx.stroke()
+        // update the bounding box
+        this.updateCanvasBoundingBox(new THREE.Vector2(centre.x - radius, centre.y - radius))
+        this.updateCanvasBoundingBox(new THREE.Vector2(centre.x + radius, centre.y + radius))
     }
 
     clear = () => {

--- a/src/ts/app/view/viewport/canvas.ts
+++ b/src/ts/app/view/viewport/canvas.ts
@@ -29,7 +29,7 @@ export interface ICanvas {
     drawTargetingLines: (point: THREE.Vector2, targetPoint: THREE.Vector2, secondaryPoints: THREE.Vector2[]) => void
     drawBox: (pointA: THREE.Vector2, pointB: THREE.Vector2, colour: string, fillColour: string) => void,
     drawLine: (pointA: THREE.Vector2, pointB: THREE.Vector2, colour: string) => void,
-    drawCircle: (centre: THREE.Vector2, radius: number, colour: string) => void,
+    drawCircle: (centre: THREE.Vector2, radius: number, colour: string, fill: boolean) => void,
     pipBounds: (width: number, height: number) => Bounds
 }
 
@@ -182,12 +182,14 @@ export class Canvas implements ICanvas {
         this.updateCanvasBoundingBox(pointB)
     }
 
-    drawCircle = (centre: THREE.Vector2, radius: number, colour: string) => {
+    drawCircle = (centre: THREE.Vector2, radius: number, colour: string, fill: boolean) => {
         this.ctx.strokeStyle = colour
         this.ctx.beginPath()
         this.ctx.arc(centre.x, centre.y, radius, 0, 2 * Math.PI, false)
-        this.ctx.fillStyle = colour
-        this.ctx.fill()
+        if (fill) {
+            this.ctx.fillStyle = colour
+            this.ctx.fill()
+        }
         this.ctx.stroke()
         // update the bounding box
         this.updateCanvasBoundingBox(new THREE.Vector2(centre.x - radius, centre.y - radius))

--- a/src/ts/app/view/viewport/handler/mouse.ts
+++ b/src/ts/app/view/viewport/handler/mouse.ts
@@ -144,32 +144,25 @@ export class MouseHandler {
     mouseDownOnSelectionHandle = () => {
         const md = this.onMouseDownPosition
         const sb = this.viewport.selectionBox
+        const hr = sb.handleRadius
         if (sb.minPosition.x === -1 && sb.minPosition.y === -1 && sb.maxPosition.x === -1 && sb.maxPosition.y === -1) {
-            console.log("inactive!!!")
+            console.log("selection box inactive!")
             return false
         }
-        if (md.x <= sb.minPosition.x + 3 && md.x >= sb.minPosition.x - 3 && md.y <= sb.minPosition.y + 3 && md.y >= sb.minPosition.y - 3) {
+        if (md.x <= sb.minPosition.x + hr && md.x >= sb.minPosition.x - hr && md.y <= sb.minPosition.y + hr && md.y >= sb.minPosition.y - hr) {
             this.handlePressed = Handle.TL
             return true
-        } else if (md.x <= sb.minPosition.x + 3 && md.x >= sb.minPosition.x - 3 && md.y <= sb.maxPosition.y + 3 && md.y >= sb.maxPosition.y - 3) {
+        } else if (md.x <= sb.minPosition.x + hr && md.x >= sb.minPosition.x - hr && md.y <= sb.maxPosition.y + hr && md.y >= sb.maxPosition.y - hr) {
             this.handlePressed = Handle.BL
             return true
-        } else if (md.x <= sb.maxPosition.x + 3 && md.x >= sb.maxPosition.x - 3 && md.y <= sb.minPosition.y + 3 && md.y >= sb.minPosition.y - 3) {
+        } else if (md.x <= sb.maxPosition.x + hr && md.x >= sb.maxPosition.x - hr && md.y <= sb.minPosition.y + hr && md.y >= sb.minPosition.y - hr) {
             this.handlePressed = Handle.TR
             return true
-        } else if (md.x <= sb.maxPosition.x + 3 && md.x >= sb.maxPosition.x - 3 && md.y <= sb.maxPosition.y + 3 && md.y >= sb.maxPosition.y - 3) {
+        } else if (md.x <= sb.maxPosition.x + hr && md.x >= sb.maxPosition.x - hr && md.y <= sb.maxPosition.y + hr && md.y >= sb.maxPosition.y - hr) {
             this.handlePressed = Handle.BR
             return true
         }
         return false
-        // return (md.x <= sb.minPosition.x + 3 && md.x >= sb.minPosition.x - 3 && md.y <= sb.minPosition.y + 3 && md.y >= sb.minPosition.y - 3)
-        // || (md.x <= sb.minPosition.x + 3 && md.x >= sb.minPosition.x - 3 && md.y <= sb.maxPosition.y + 3 && md.y >= sb.maxPosition.y - 3)
-        // || (md.x <= sb.maxPosition.x + 3 && md.x >= sb.maxPosition.x - 3 && md.y <= sb.minPosition.y + 3 && md.y >= sb.minPosition.y - 3)
-        // || (md.x <= sb.maxPosition.x + 3 && md.x >= sb.maxPosition.x - 3 && md.y <= sb.maxPosition.y + 3 && md.y >= sb.maxPosition.y - 3)
-        // return (md.x <= sb.minPosition.x + 3 && md.x >= sb.minPosition.x - 3 && ((md.y <= sb.minPosition.y + 3 && md.y >= sb.minPosition.y - 3)
-        // || (md.y <= sb.maxPosition.y + 3 && md.y >= sb.maxPosition.y - 3)))
-        // || (md.x <= sb.maxPosition.x + 3 && md.x >= sb.maxPosition.x - 3 && ((md.y <= sb.minPosition.y + 3 && md.y >= sb.minPosition.y)
-        // || (md.y <= sb.maxPosition.y + 3 && md.y >= sb.maxPosition.y - 3)))
     }
 
     // Catch all clicks and delegate to other handlers once user's intent
@@ -294,25 +287,26 @@ export class MouseHandler {
         var newPosition = new THREE.Vector2(event.clientX, event.clientY)
         // clear the canvas and draw a selection rect.
         this.viewport.clearCanvas()
-        this.viewport.canvas.drawSelectionBox(this.onMouseDownPosition, newPosition)
+        this.viewport.canvas.drawBox(this.onMouseDownPosition, newPosition, "rgb(1, 230, 251)", "rgba(0, 0, 0, 0)")
     }
 
     selectionHandleOnDrag = (event: MouseEvent) => {
         console.log("selection handle:drag")
-        const oldMin = this.viewport.selectionBox.minPosition
-        const oldMax = this.viewport.selectionBox.maxPosition
+        const p = this.viewport.selectionBox.padding
+        const oldMin = this.viewport.selectionBox.minPosition.clone().add(new THREE.Vector2(p, p))
+        const oldMax = this.viewport.selectionBox.maxPosition.clone().sub(new THREE.Vector2(p, p))
         const newMin = oldMin.clone()
         const newMax = oldMax.clone()
         if (this.handlePressed === Handle.TL) {
-            newMin.set(event.clientX, event.clientY)
+            newMin.set(event.clientX + p, event.clientY + p)
         } else if (this.handlePressed === Handle.BR) {
-            newMax.set(event.clientX, event.clientY)
+            newMax.set(event.clientX - p, event.clientY - p)
         } else if (this.handlePressed === Handle.TR) {
-            newMin.y = event.clientY
-            newMax.x = event.clientX
+            newMin.y = event.clientY + p
+            newMax.x = event.clientX - p
         } else {
-            newMin.x = event.clientX
-            newMax.y = event.clientY
+            newMin.x = event.clientX + p
+            newMax.y = event.clientY - p
         }
         this.viewport.selectedLandmarks.forEach(lm => {
             // convert to screen coordinates

--- a/src/ts/app/view/viewport/handler/mouse.ts
+++ b/src/ts/app/view/viewport/handler/mouse.ts
@@ -464,10 +464,14 @@ export class MouseHandler {
 
         this.viewport.clearCanvas()
 
+        if (this.isPressed) {
+            return
+        }
+
         // update and draw selection box if active
         this.viewport.updateSelectionBox()
 
-        if (this.isPressed || !this.viewport.landmarkSnapPermitted) {
+        if (!this.viewport.landmarkSnapPermitted) {
             return
         }
 

--- a/src/ts/app/view/viewport/handler/mouse.ts
+++ b/src/ts/app/view/viewport/handler/mouse.ts
@@ -330,7 +330,6 @@ export class MouseHandler {
                 newLmX, newLmY, this.viewport.scene.mesh)
             if (this.intersectsWithMesh.length > 0) {
                 // good, we're still on the mesh.
-                // TODO check
                 this.dragged = !!this.dragged || true
                 this.viewport.on.setLandmarkPointWithoutHistory(lm.index,
                     this.viewport.scene.worldToLocal(this.intersectsWithMesh[0].point))

--- a/src/ts/app/view/viewport/handler/mouse.ts
+++ b/src/ts/app/view/viewport/handler/mouse.ts
@@ -112,24 +112,9 @@ export class MouseHandler {
 
         if (!(this.downEvent.ctrlKey || this.downEvent.metaKey)) {
             this.viewport.on.deselectAllLandmarks()
-            this.viewport.clearCanvas()
         }
         document.addEventListener('mousemove', this.shiftOnDrag)
         listenOnce(document, 'mouseup', this.shiftOnMouseUp)
-    }
-
-    updateSelectionBox = () => {
-        if (this.viewport.selectedLandmarks.length > 1) {
-            var xs = this.viewport.selectedLandmarks.map(lm => this.viewport.scene.localToScreen(lm.point).x)
-            var ys = this.viewport.selectedLandmarks.map(lm => this.viewport.scene.localToScreen(lm.point).y)
-            var minX = Math.min(...xs)
-            var maxX = Math.max(...xs)
-            var minY = Math.min(...ys)
-            var maxY = Math.max(...ys)
-            var minPosition = new THREE.Vector2(minX, minY)
-            var maxPosition = new THREE.Vector2(maxX, maxY)
-            this.viewport.canvas.drawSelectionBox(minPosition, maxPosition)
-        }
     }
 
     // Catch all clicks and delegate to other handlers once user's intent
@@ -193,7 +178,6 @@ export class MouseHandler {
                 this.intersectsWithMesh.length > 0
             ) {
                 this.viewport.on.deselectAllLandmarks()
-                this.viewport.clearCanvas()
                 this.currentTargetLm = null
                 this.meshPressed()
             }
@@ -238,7 +222,6 @@ export class MouseHandler {
                 console.log("fallen off mesh")
             }
         })
-        this.updateSelectionBox()
         this.viewport.requestUpdate()
     }
 
@@ -282,8 +265,7 @@ export class MouseHandler {
         // obscured) and select the rest
         const indexesToSelect = lms.filter(this.viewport.scene.lmViewVisible).map(lm => lm.index)
         this.viewport.on.selectLandmarks(indexesToSelect)
-        this.viewport.requestUpdateAndClearCanvas()
-        this.updateSelectionBox()
+        this.viewport.requestUpdateAndRefreshCanvas()
         this.isPressed = false
     }
 
@@ -319,6 +301,7 @@ export class MouseHandler {
         }
         this.isPressed = false
         this.viewport.clearCanvas()
+        this.viewport.updateSelectionBox()
     }
 
     landmarkOnMouseUp = (event: MouseEvent) => {
@@ -345,9 +328,7 @@ export class MouseHandler {
             this.viewport.on.addLandmarkHistory(this.dragStartPositions)
         }
 
-        this.viewport.clearCanvas()
-        this.updateSelectionBox()
-        this.viewport.requestUpdate()
+        this.viewport.requestUpdateAndRefreshCanvas()
         this.dragged = false
         this.dragStartPositions = []
         this.isPressed = false
@@ -360,7 +341,7 @@ export class MouseHandler {
         this.viewport.clearCanvas()
 
         // update and draw selection box if active
-        this.updateSelectionBox()
+        this.viewport.updateSelectionBox()
 
         if (this.isPressed || !this.viewport.landmarkSnapPermitted) {
             return

--- a/src/ts/app/view/viewport/handler/mouse.ts
+++ b/src/ts/app/view/viewport/handler/mouse.ts
@@ -182,16 +182,21 @@ export class MouseHandler {
             console.log("selection box inactive!")
             return false
         }
-        if (md.x <= sb.minPosition.x + hr && md.x >= sb.minPosition.x - hr && md.y <= sb.minPosition.y + hr && md.y >= sb.minPosition.y - hr) {
+        // add one pixel padding to make handle easier to grab
+        if (md.x <= sb.minPosition.x + hr + 1 && md.x >= sb.minPosition.x - hr - 1
+        && md.y <= sb.minPosition.y + hr + 1 && md.y >= sb.minPosition.y - hr - 1) {
             this.handlePressed = Handle.TL
             return true
-        } else if (md.x <= sb.minPosition.x + hr && md.x >= sb.minPosition.x - hr && md.y <= sb.maxPosition.y + hr && md.y >= sb.maxPosition.y - hr) {
+        } else if (md.x <= sb.minPosition.x + hr + 1 && md.x >= sb.minPosition.x - hr - 1
+        && md.y <= sb.maxPosition.y + hr + 1 && md.y >= sb.maxPosition.y - hr - 1) {
             this.handlePressed = Handle.BL
             return true
-        } else if (md.x <= sb.maxPosition.x + hr && md.x >= sb.maxPosition.x - hr && md.y <= sb.minPosition.y + hr && md.y >= sb.minPosition.y - hr) {
+        } else if (md.x <= sb.maxPosition.x + hr + 1 && md.x >= sb.maxPosition.x - hr - 1
+        && md.y <= sb.minPosition.y + hr + 1 && md.y >= sb.minPosition.y - hr - 1) {
             this.handlePressed = Handle.TR
             return true
-        } else if (md.x <= sb.maxPosition.x + hr && md.x >= sb.maxPosition.x - hr && md.y <= sb.maxPosition.y + hr && md.y >= sb.maxPosition.y - hr) {
+        } else if (md.x <= sb.maxPosition.x + hr + 1 && md.x >= sb.maxPosition.x - hr - 1
+        && md.y <= sb.maxPosition.y + hr + 1 && md.y >= sb.maxPosition.y - hr - 1) {
             this.handlePressed = Handle.BR
             return true
         }
@@ -223,7 +228,8 @@ export class MouseHandler {
         }
         const deltaX = (md.x - ((sb.minPosition.x + sb.maxPosition.x) / 2))
         const deltaY = (md.y - (sb.minPosition.y - (hr * 3)))
-        return Math.sqrt((deltaX * deltaX) + (deltaY * deltaY)) <= hr
+        // add one pixel padding to make handle easier to grab
+        return Math.sqrt((deltaX * deltaX) + (deltaY * deltaY)) <= hr + 1
     }
 
     // Catch all clicks and delegate to other handlers once user's intent

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -185,7 +185,7 @@ export class Viewport implements IViewport {
                                          this.scene.sOCam,
                                          this.scene.sOCamZoom)
 
-        this.camera.onChange = this.requestUpdateAndClearCanvas
+        this.camera.onChange = this.requestUpdateAndRefreshCanvas
         // set the cameera lock status to false, which will wire up the handlers.
         this.cameraIsLocked = false
 
@@ -391,6 +391,7 @@ export class Viewport implements IViewport {
         this.on.addLandmarkHistory(ops)
 
         this.clearCanvas()
+        this.updateSelectionBox()
     }
 
      animate = () => {
@@ -452,6 +453,11 @@ export class Viewport implements IViewport {
         this.clearCanvas()
     }
 
+    requestUpdateAndRefreshCanvas = () => {
+        this.requestUpdateAndClearCanvas()
+        this.updateSelectionBox()
+    }
+
     memoryString = () => {
         return 'geo:' + this.renderer.info.memory.geometries +
                ' tex:' + this.renderer.info.memory.textures
@@ -478,6 +484,24 @@ export class Viewport implements IViewport {
             this.scene.localToScreen(targetLm.point),
             secondaryLms.map(lm => this.scene.localToScreen(lm.point))
         )
+    }
+
+    updateSelectionBox = () => {
+        if (this.selectedLandmarks.length > 1) {
+            var xs = this.selectedLandmarks.map(lm => this.scene.localToScreen(lm.point).x)
+            var ys = this.selectedLandmarks.map(lm => this.scene.localToScreen(lm.point).y)
+            var minX = Math.min(...xs)
+            var maxX = Math.max(...xs)
+            var minY = Math.min(...ys)
+            var maxY = Math.max(...ys)
+            var minPosition = new THREE.Vector2(minX, minY)
+            var maxPosition = new THREE.Vector2(maxX, maxY)
+            this.canvas.drawSelectionBox(minPosition, maxPosition)
+            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, minY - 3), new THREE.Vector2(minX + 4, minY + 4))
+            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, maxY - 3), new THREE.Vector2(minX + 4, maxY + 4))
+            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, minY - 3), new THREE.Vector2(maxX + 4, minY + 4))
+            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, maxY - 3), new THREE.Vector2(maxX + 4, maxY + 4))
+        }
     }
 
 }

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -514,6 +514,8 @@ export class Viewport implements IViewport {
             this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, maxY - 3), new THREE.Vector2(minX + 3, maxY + 3))
             this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, minY - 3), new THREE.Vector2(maxX + 3, minY + 3))
             this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, maxY - 3), new THREE.Vector2(maxX + 3, maxY + 3))
+            this.canvas.drawLine(new THREE.Vector2((minX + maxX) / 2, minY), new THREE.Vector2((minX + maxX) / 2, minY - 5))
+            this.canvas.drawCircle(new THREE.Vector2((minX + maxX) / 2, minY - 8), 3)
             this.selectionBox = {
                 minPosition: minPosition,
                 maxPosition: maxPosition

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -35,7 +35,7 @@ export interface IViewport {
     resetCamera: () => void,
     toggleCamera: () => void
     snapModeEnabled: boolean
-    connectivityVisable: boolean
+    connectivityVisible: boolean
     cameraIsLocked: boolean
     landmarkSnapPermitted: boolean
     memoryString: () => string
@@ -140,7 +140,7 @@ export class Viewport implements IViewport {
 
     meshMode: boolean   // if true, working with 3D meshes. False, 2D images.
     on: ViewportCallbacks
-    _connectivityVisable = true
+    _connectivityVisible = true
     _snapModeEnabled: boolean // Note that we need to fire this in the constructor for sideeffects
 
     parent: HTMLElement
@@ -260,12 +260,12 @@ export class Viewport implements IViewport {
         return this.nonEmptyLandmarks.length === 0
     }
 
-    get connectivityVisable() {
-        return this._connectivityVisable
+    get connectivityVisible() {
+        return this._connectivityVisible
     }
 
-    set connectivityVisable (connectivityVisable: boolean) {
-        this._connectivityVisable = connectivityVisable
+    set connectivityVisible (connectivityVisible: boolean) {
+        this._connectivityVisible = connectivityVisible
         this.requestUpdate()
     }
 
@@ -348,11 +348,11 @@ export class Viewport implements IViewport {
         if (currentMode === CAMERA_MODE.PERSPECTIVE) {
             // going to orthographic - start listening for pip updates
             this.camera.onChangePip = this.requestUpdate
-            this.canvas.pipVisable = true
+            this.canvas.pipVisible = true
         } else {
             // leaving orthographic - stop listening to pip calls.
             this.camera.onChangePip = null
-            this.canvas.pipVisable = false
+            this.canvas.pipVisible = false
         }
         // clear the canvas and re-render our state
         this.requestUpdateAndClearCanvas()
@@ -415,7 +415,7 @@ export class Viewport implements IViewport {
         this.renderer.clear()
         this.renderer.render(scene.scene, scene.sCamera)
 
-        if (this.connectivityVisable) {
+        if (this.connectivityVisible) {
             // clear depth buffer
             this.renderer.clearDepth()
             // and render the connectivity
@@ -435,7 +435,7 @@ export class Viewport implements IViewport {
 
             // render the PIP image
             this.renderer.render(scene.scene, scene.sOCamZoom)
-            if (this.connectivityVisable) {
+            if (this.connectivityVisible) {
                 this.renderer.clearDepth() // clear depth buffer
                 // and render the connectivity
                 this.renderer.render(scene.sceneHelpers, scene.sOCamZoom)

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -172,6 +172,7 @@ export class Viewport implements IViewport {
     touchHandler: TouchHandler
 
     selectionBox: SelectionBox
+    rotationCircleActive: boolean
 
     constructor(parent: HTMLElement, meshMode: boolean, on: ViewportCallbacks, verbose = false) {
         if (verbose) {
@@ -247,6 +248,7 @@ export class Viewport implements IViewport {
             colour: "rgb(1, 230, 251)",
             fillColour: "rgba(1, 230, 251, 0.2)"
         }
+        this.rotationCircleActive = false
     }
 
     get width() {
@@ -412,7 +414,7 @@ export class Viewport implements IViewport {
         this.on.addLandmarkHistory(ops)
 
         this.clearCanvas()
-        this.updateSelectionBox()
+        this.drawSelectionElements()
     }
 
      animate = () => {
@@ -476,7 +478,7 @@ export class Viewport implements IViewport {
 
     requestUpdateAndRefreshCanvas = () => {
         this.requestUpdateAndClearCanvas()
-        this.updateSelectionBox()
+        this.drawSelectionElements()
     }
 
     memoryString = () => {
@@ -507,7 +509,15 @@ export class Viewport implements IViewport {
         )
     }
 
-    updateSelectionBox = () => {
+    drawSelectionElements = () => {
+        if (this.rotationCircleActive) {
+            this.drawRotationCircle()
+        } else {
+            this.updateAndDrawSelectionBox()
+        }
+    }
+
+    updateAndDrawSelectionBox = () => {
         var col = this.selectionBox.colour
         var fillCol = this.selectionBox.fillColour
         var fillEmpty = "rgba(0, 0, 0, 0)"
@@ -530,7 +540,7 @@ export class Viewport implements IViewport {
             this.canvas.drawBox(new THREE.Vector2(maxX - hr, minY - hr), new THREE.Vector2(maxX + hr, minY + hr), col, fillEmpty)
             this.canvas.drawBox(new THREE.Vector2(maxX - hr, maxY - hr), new THREE.Vector2(maxX + hr, maxY + hr), col, fillEmpty)
             this.canvas.drawLine(new THREE.Vector2((minX + maxX) / 2, minY), new THREE.Vector2((minX + maxX) / 2, minY - (hr * 2)), col)
-            this.canvas.drawCircle(new THREE.Vector2((minX + maxX) / 2, minY - (hr * 3)), hr, col)
+            this.canvas.drawCircle(new THREE.Vector2((minX + maxX) / 2, minY - (hr * 3)), hr, col, true)
             this.selectionBox = {
                 minPosition: minPosition,
                 maxPosition: maxPosition,
@@ -549,6 +559,23 @@ export class Viewport implements IViewport {
                 fillColour: "rgba(1, 230, 251, 0.2)"
             }
         }
+    }
+
+    drawRotationCircle = () => {
+        var col = this.selectionBox.colour
+        var min = this.selectionBox.minPosition
+        var max = this.selectionBox.maxPosition
+        var centre = new THREE.Vector2((min.x + max.x) / 2, (min.y + max.y) / 2)
+        var radius = Math.min((max.x - min.x) / 2, (max.y - min.y) / 2)
+        this.canvas.drawCircle(centre, radius, col, false)
+    }
+
+    activateRotationCircle = () => {
+        this.rotationCircleActive = true
+    }
+
+    deactivateRotationCircle = () => {
+        this.rotationCircleActive = false
     }
 
 }

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -48,6 +48,10 @@ export interface IViewportOptions {
 interface SelectionBox {
     minPosition: THREE.Vector2
     maxPosition: THREE.Vector2
+    handleRadius: number
+    padding: number
+    colour: string
+    fillColour: string
 }
 
 function wrapViewportCallbacksInDebug(on:ViewportCallbacks): ViewportCallbacks {
@@ -237,7 +241,11 @@ export class Viewport implements IViewport {
         // invalid selection box - not active
         this.selectionBox = {
             minPosition: new THREE.Vector2(-1, -1),
-            maxPosition: new THREE.Vector2(-1, -1)
+            maxPosition: new THREE.Vector2(-1, -1),
+            handleRadius: -1,
+            padding: -1,
+            colour: "rgb(1, 230, 251)",
+            fillColour: "rgba(1, 230, 251, 0.2)"
         }
     }
 
@@ -500,30 +508,45 @@ export class Viewport implements IViewport {
     }
 
     updateSelectionBox = () => {
+        var col = this.selectionBox.colour
+        var fillCol = this.selectionBox.fillColour
+        var fillEmpty = "rgba(0, 0, 0, 0)"
         if (this.selectedLandmarks.length > 1) {
             var xs = this.selectedLandmarks.map(lm => this.scene.localToScreen(lm.point).x)
             var ys = this.selectedLandmarks.map(lm => this.scene.localToScreen(lm.point).y)
-            var minX = Math.min(...xs)
-            var maxX = Math.max(...xs)
-            var minY = Math.min(...ys)
-            var maxY = Math.max(...ys)
+            var padding = 7
+            var minX = Math.min(...xs) - padding
+            var maxX = Math.max(...xs) + padding
+            var minY = Math.min(...ys) - padding
+            var maxY = Math.max(...ys) + padding
             var minPosition = new THREE.Vector2(minX, minY)
             var maxPosition = new THREE.Vector2(maxX, maxY)
-            this.canvas.drawSelectionBox(minPosition, maxPosition)
-            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, minY - 3), new THREE.Vector2(minX + 3, minY + 3))
-            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, maxY - 3), new THREE.Vector2(minX + 3, maxY + 3))
-            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, minY - 3), new THREE.Vector2(maxX + 3, minY + 3))
-            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, maxY - 3), new THREE.Vector2(maxX + 3, maxY + 3))
-            this.canvas.drawLine(new THREE.Vector2((minX + maxX) / 2, minY), new THREE.Vector2((minX + maxX) / 2, minY - 5))
-            this.canvas.drawCircle(new THREE.Vector2((minX + maxX) / 2, minY - 8), 3)
+            var col = this.selectionBox.colour
+            this.canvas.drawBox(minPosition, maxPosition, col, fillCol)
+            // selection box handles
+            var hr = 4
+            this.canvas.drawBox(new THREE.Vector2(minX - hr, minY - hr), new THREE.Vector2(minX + hr, minY + hr), col, fillEmpty)
+            this.canvas.drawBox(new THREE.Vector2(minX - hr, maxY - hr), new THREE.Vector2(minX + hr, maxY + hr), col, fillEmpty)
+            this.canvas.drawBox(new THREE.Vector2(maxX - hr, minY - hr), new THREE.Vector2(maxX + hr, minY + hr), col, fillEmpty)
+            this.canvas.drawBox(new THREE.Vector2(maxX - hr, maxY - hr), new THREE.Vector2(maxX + hr, maxY + hr), col, fillEmpty)
+            this.canvas.drawLine(new THREE.Vector2((minX + maxX) / 2, minY), new THREE.Vector2((minX + maxX) / 2, minY - (hr * 2)), col)
+            this.canvas.drawCircle(new THREE.Vector2((minX + maxX) / 2, minY - (hr * 3)), hr, col)
             this.selectionBox = {
                 minPosition: minPosition,
-                maxPosition: maxPosition
+                maxPosition: maxPosition,
+                handleRadius: hr,
+                padding: padding,
+                colour: "rgb(1, 230, 251)",
+                fillColour: "rgba(1, 230, 251, 0.2)"
             }
         } else {
             this.selectionBox = {
                 minPosition: new THREE.Vector2(-1, -1),
-                maxPosition: new THREE.Vector2(-1, -1)
+                maxPosition: new THREE.Vector2(-1, -1),
+                handleRadius: -1,
+                padding: -1,
+                colour: "rgb(1, 230, 251)",
+                fillColour: "rgba(1, 230, 251, 0.2)"
             }
         }
     }

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -337,7 +337,7 @@ export class Viewport implements IViewport {
 
     updateLandmarks = (landmarks: Landmark[]) => {
         this.scene.updateLandmarks(landmarks)
-        this.requestUpdate()
+        this.requestUpdateAndRefreshCanvas()
     }
 
     setMesh = (mesh: THREE.Mesh, up: THREE.Vector3, front: THREE.Vector3) => {

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -45,6 +45,11 @@ export interface IViewportOptions {
     verbose?: false
 }
 
+interface SelectionBox {
+    minPosition: THREE.Vector2
+    maxPosition: THREE.Vector2
+}
+
 function wrapViewportCallbacksInDebug(on:ViewportCallbacks): ViewportCallbacks {
     return {
         selectLandmarks: (indicies: number[]) => {
@@ -162,6 +167,8 @@ export class Viewport implements IViewport {
     mouseHandler: MouseHandler
     touchHandler: TouchHandler
 
+    selectionBox: SelectionBox
+
     constructor(parent: HTMLElement, meshMode: boolean, on: ViewportCallbacks, verbose = false) {
         if (verbose) {
             on = wrapViewportCallbacksInDebug(on)
@@ -226,6 +233,12 @@ export class Viewport implements IViewport {
         this.animate()
 
         this.snapModeEnabled = true
+
+        // invalid selection box - not active
+        this.selectionBox = {
+            minPosition: new THREE.Vector2(-1, -1),
+            maxPosition: new THREE.Vector2(-1, -1)
+        }
     }
 
     get width() {
@@ -497,10 +510,19 @@ export class Viewport implements IViewport {
             var minPosition = new THREE.Vector2(minX, minY)
             var maxPosition = new THREE.Vector2(maxX, maxY)
             this.canvas.drawSelectionBox(minPosition, maxPosition)
-            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, minY - 3), new THREE.Vector2(minX + 4, minY + 4))
-            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, maxY - 3), new THREE.Vector2(minX + 4, maxY + 4))
-            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, minY - 3), new THREE.Vector2(maxX + 4, minY + 4))
-            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, maxY - 3), new THREE.Vector2(maxX + 4, maxY + 4))
+            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, minY - 3), new THREE.Vector2(minX + 3, minY + 3))
+            this.canvas.drawSelectionBox(new THREE.Vector2(minX - 3, maxY - 3), new THREE.Vector2(minX + 3, maxY + 3))
+            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, minY - 3), new THREE.Vector2(maxX + 3, minY + 3))
+            this.canvas.drawSelectionBox(new THREE.Vector2(maxX - 3, maxY - 3), new THREE.Vector2(maxX + 3, maxY + 3))
+            this.selectionBox = {
+                minPosition: minPosition,
+                maxPosition: maxPosition
+            }
+        } else {
+            this.selectionBox = {
+                minPosition: new THREE.Vector2(-1, -1),
+                maxPosition: new THREE.Vector2(-1, -1)
+            }
         }
     }
 


### PR DESCRIPTION
_This PR has a staging branch, which means a production build of this branch exists and can be launched. [**Click here**](https://www.landmarker.io/staging/selection_box) to preview this PR._

This feature involves a persistent selection box which appears whenever more than one landmark is selected.

The selection box allows the user to click and drag inside it in order to translate all selected landmarks. Clicking any landmarks inside the box results in the default behaviour, however.

The selection box has 'handles' in each corner which can be used to scale the selected landmark positions. It also has a circular 'handle' which can be used to rotate selected landmarks around the centre of the selection box.

There are currently problems with the current selection box implementation. Dragging a scaling handle off the mesh and further can cause the selection box to visibly flicker. Also, the selection box persists even when the selected landmarks are occluded by the mesh. If you transform these selected, occluded landmarks in any way, they will 'teleport' to the near side of the mesh.