### PR TITLE
(WIP) make the viewport positioning work when there is an offset

### DIFF
--- a/src/ts/app/view/viewport/camera/base.ts
+++ b/src/ts/app/view/viewport/camera/base.ts
@@ -271,7 +271,6 @@ export class Camera implements ICamera {
     }
 
     rotate = (delta: THREE.Vector3, singleDir=false) => {
-        console.log(delta)
         if (this.rotationPermitted) {
             [this.pCam, this.oCam, this.oCamZoom].map(
                 c => this.rotateOneCamera(delta, c, singleDir))

--- a/src/ts/app/view/viewport/handler/touch.ts
+++ b/src/ts/app/view/viewport/handler/touch.ts
@@ -1,6 +1,3 @@
-import * as THREE from 'three'
-import * as $ from 'jquery'
-import { Landmark } from '../base'
 import { Viewport } from '../index'
 import { touchListByType } from '../lib/touch'
 import { findClosestLandmarks } from './base'

--- a/src/ts/app/view/viewport/index.ts
+++ b/src/ts/app/view/viewport/index.ts
@@ -578,4 +578,13 @@ export class Viewport implements IViewport {
         this.rotationCircleActive = false
     }
 
+    positionInParent = (event: MouseEvent) => {
+        // note - we use client as we don't want to jump back to zero
+        // if user drags into sidebar!
+        return new THREE.Vector2(
+            event.clientX - this.parent.offsetLeft,
+            event.clientY - this.parent.offsetTop
+        )
+    }
+
 }

--- a/src/ts/app/view/viewport/scene/index.ts
+++ b/src/ts/app/view/viewport/scene/index.ts
@@ -303,7 +303,9 @@ export class Scene implements IScene {
         return this.getUnsortedIntersects(x, y, object).sort((a, b) => a.distance - b.distance)
     }
 
-    getIntersectsFromEvent = (e: MouseEvent | Touch, object: Intersectable) => this.getIntersects(e.pageX, e.clientY, object)
+    getIntersectsFromEvent = (e: MouseEvent | Touch, object: Intersectable) => {
+        return this.getIntersects(e.pageX, e.clientY, object)
+    }
 
     worldToScreen = (v: THREE.Vector3) => {
         const halfW = this.width / 2


### PR DESCRIPTION
This starts to standardize how we return the current mouse position in the div that is being used to render the viewport. Once complete we will be able to embed the viewport at an offset on a page and have it work. This is a step towards enabling the viewport to be used in other applications (e.g. as an IPython widget).

Also cleans up a few unnecessary imports.